### PR TITLE
Feature order by priority in the index page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ Metrics/BlockLength:
     - '**/*.rake'
     - 'spec/**/*.rb'
 
+Metrics/MethodLength:
+  Max: 20
+
 Style/StringLiterals:
   Exclude:
     - 'spec/*_helper.rb'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def sortable(column)
     direction = params[:direction] == 'DESC' ? 'ASC' : 'DESC'
-    link_to t('tasks.end_at'), order_by: column, direction: direction
+    link_to t("tasks.#{column}"), order_by: column.split('.')[0], direction: direction
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
-  def sortable(column)
+  def sortable_link_to(column)
     direction = params[:direction] == 'DESC' ? 'ASC' : 'DESC'
     link_to t("tasks.#{column}"), order_by: column.split('.')[0], direction: direction
   end

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -13,7 +13,7 @@
     <tr>
       <th scope="col"><%= t("tasks.page_title.task") %></th>
       <th scope="col"><%= t("tasks.status.title") %></th>
-      <th scope="col"><%= t("tasks.priority.title") %></th>
+      <th scope="col"><%= sortable "priority.title" %></th>
       <th scope="col"><%= t("tasks.start_at") %></th>
       <th scope="col"><%= sortable "end_at" %></th>
       <th scope="col"></th>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -13,9 +13,9 @@
     <tr>
       <th scope="col"><%= t("tasks.page_title.task") %></th>
       <th scope="col"><%= t("tasks.status.title") %></th>
-      <th scope="col"><%= sortable "priority.title" %></th>
+      <th scope="col"><%= sortable_link_to "priority.title" %></th>
       <th scope="col"><%= t("tasks.start_at") %></th>
-      <th scope="col"><%= sortable "end_at" %></th>
+      <th scope="col"><%= sortable_link_to "end_at" %></th>
       <th scope="col"></th>
     </tr>
   </thead>

--- a/spec/features/task_spec.rb
+++ b/spec/features/task_spec.rb
@@ -130,19 +130,21 @@ RSpec.feature 'Tasks', type: :feature do
   end
 
   def expect_sort_by_column(button)
+    tasks = { first: Task.first, second: Task.second }
+
     click_link button
     within 'tbody tr:nth-child(1)' do
-      expect(page).to have_content(Task.second.title)
+      expect(page).to have_content(tasks[:second].title)
     end
     within 'tbody tr:nth-child(2)' do
-      expect(page).to have_content(Task.first.title)
+      expect(page).to have_content(tasks[:first].title)
     end
     click_link button
     within 'tbody tr:nth-child(1)' do
-      expect(page).to have_content(Task.first.title)
+      expect(page).to have_content(tasks[:first].title)
     end
     within 'tbody tr:nth-child(2)' do
-      expect(page).to have_content(Task.second.title)
+      expect(page).to have_content(tasks[:second].title)
     end
   end
 

--- a/spec/features/task_spec.rb
+++ b/spec/features/task_spec.rb
@@ -51,8 +51,8 @@ RSpec.feature 'Tasks', type: :feature do
   end
 
   describe 'Sort task flow', js: true do
-    let(:first_task) { create(:task, created_at: '2020-01-31 11:00') }
-    let(:second_task) { create(:task, created_at: '2020-02-01 11:00', end_at: first_task.end_at + 1.days) }
+    let(:first_task) { create(:task, created_at: '2020-01-31 11:00', priority: 'high') }
+    let(:second_task) { create(:task, created_at: '2020-02-01 11:00', end_at: first_task.end_at + 1.days, priority: 'low') }
 
     scenario 'Default sort by created_at' do
       first_task
@@ -68,20 +68,12 @@ RSpec.feature 'Tasks', type: :feature do
 
     scenario 'When sort by end_at' do
       visit root_path
-      click_link '結束時間'
-      within 'tbody tr:nth-child(1)' do
-        expect(page).to have_content(Task.second.title)
-      end
-      within 'tbody tr:nth-child(2)' do
-        expect(page).to have_content(Task.first.title)
-      end
-      click_link '結束時間'
-      within 'tbody tr:nth-child(1)' do
-        expect(page).to have_content(Task.first.title)
-      end
-      within 'tbody tr:nth-child(2)' do
-        expect(page).to have_content(Task.second.title)
-      end
+      expect_sort_by_column('結束時間')
+    end
+
+    scenario 'When sort by priority' do
+      visit root_path
+      expect_sort_by_column('優先順序')
     end
   end
 
@@ -135,6 +127,23 @@ RSpec.feature 'Tasks', type: :feature do
     expect(task.end_at).to eq 'Thu, 30 Jan 2020 23:15:17 +0800'
     expect(task.status).to eq 'pending'
     expect(task.priority).to eq 'high'
+  end
+
+  def expect_sort_by_column(button)
+    click_link button
+    within 'tbody tr:nth-child(1)' do
+      expect(page).to have_content(Task.second.title)
+    end
+    within 'tbody tr:nth-child(2)' do
+      expect(page).to have_content(Task.first.title)
+    end
+    click_link button
+    within 'tbody tr:nth-child(1)' do
+      expect(page).to have_content(Task.first.title)
+    end
+    within 'tbody tr:nth-child(2)' do
+      expect(page).to have_content(Task.second.title)
+    end
   end
 
   def except_search_result_with(title = nil, status = nil)


### PR DESCRIPTION
- Edit helper method 'sortable' to support different variable column
- Edit view 'tasks/index.erb.html', link sortable
- Spec - feature-test
 - Add scenario 'When sort by priority'
   - Refactoring two scenario by use private method 'expect_sort_by_column'
   - Add Metrics/MethodLength: Max: 20 to solve method is too many lines (14/13)